### PR TITLE
add a step sequencer and a mic recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+In the little prompt asking what we could bring to learning Music/Synth, I suggested the idea of writing a little chapter on the history of sampling. So I connected this idea with the challenge.
+
+I suggested giving the user the ability to play with their own samples.
+
+That being said, I implemented here three features:
+ 
+ - Gain visualization on the xyPad: I used Tone.js Meter to create a Gain visualizer around the XY pad. 
+
+ - Step sequencer: the sequencer is taking care of replaying the user interaction precisely. It is simulating mouse events, so the user can see exactly what they played. it is using a web worker to generate a consistent and steady loop event.
+
+ - Mic recorder: the mic recorder is allowing the user to record and play with their own samples.
+ 
+
+## What else has been done 
+ - Converted actual web audio nodes to Tone.js nodes in order to use a meter node.
+ - Fixed a bug due to an un-triggered mouseUp event when the user is moving the cursor out of the xyPad area. We are now listening for window mouseUp events and forcing the playback to stop.
+ - refactor xyPad events callback.
+ - Implementing an EventBus to do bidirectional event dispatch across different files, also improves code readability.
+ - installed Tailwind and daisyUI via CDN to improve overall UI.

--- a/index.html
+++ b/index.html
@@ -1,70 +1,50 @@
 <html>
-    <head>
-        <title>XY Sample Player</title>
-        <link rel="stylesheet" href="styles.css">
-        <script type="module" src="main.js"></script>
-    </head>
-    <body>
-        <h1>XY Sample Player</h1>
-        <h2>Learning Team | Software Engineer Test</h2>
-        <p>
-            This page allows a musician to play back an audio sample using a simple <i>xy-pad</i> control.
-            The two-dimensional nature of this interface allows for playful interaction with many aspects of the generated sound.
-        </p>
 
-        <p>
-            While the pad is pressed, the sample should play back in a continuous loop. The sample should stop
-            playing when the pad is released.
-        </p>
+<head>
+    <title>XY Sample Player</title>
+    <link rel="stylesheet" href="styles.css">
+    <link href="https://cdn.jsdelivr.net/npm/daisyui@2.31.0/dist/full.css" rel="stylesheet" type="text/css" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.48/Tone.min.js"></script>
+    <script type="module" src="main.js"></script>
 
-        <p>
-            Moving your pointer up and down changes the playback rate of the sample. Moving your pointer left
-            and right changes the <i>cutoff frequency</i> of a filter that's being applied
-            to the sound.
-        </p>
+</head>
 
-        <p>
-            Give it a try by pressing and dragging in the gray square below:
-        </p>
-        <section class="two_row">
-            <svg class="xy_pad" id="xy_pad">
-                <circle cx="50%" cy="50%" r="3" opacity="0.5"></circle>
-            </svg>
-            <div class="sample_display">
-                <div id="loading_indicator">Loading Sample...</div>
-            </div>
-        </section>
+<body>
+    <div class="flex items-center justify-center ">
+        <div>
+            <h1 class="text-6xl mt-24 mb-12">Record and play </br>your own samples.</h1>
+            <p class="text-2xl mb-12">This section allows you to record and play you own samples.</p>
+            <p class="mb-6"> - Every time you play with the pad, your movements are recorded and can be played again
+                using the "play" button.</p>
+            <p> - You can also reccord your own sample using your microphone and play with it. Click on the "mic" button
+                to start recording.</p>
+            <section class="two_row mt-24 mb-56">
+                <svg id="xy_pad">
+                    <circle cx="50%" cy="50%" r="3" opacity="0.5"></circle>
+                </svg>
 
-        <hr/>
+                <button id="start" class="btn btn-square btn-warning btn-disabled">
+                    play
+                </button>
 
-        <h2>Your task</h2>
+                <button id="stop" style="display: none;" class="btn btn-square btn-success">
+                    stop
+                </button>
 
-        <p>
-            Spend no more than three hours making improvements to this page.
-            When you've reached the time limit, zip up the entire project folder and send it back to us.
-        </p>
+                <button style="float: right;" class="record-mic btn btn-circle btn-error">
+                    mic
+                </button>
 
-        <p>
-            We're open to any changes you decide to make. Feel free to add files and adjust anything that's here.
-            You might choose to identify and fix bugs, make general code improvements, write documentation,
-            improve performance, introduce entirely new features, or do something else we haven't anticipated!
-            Please provide a brief rationale for your changes in code comments, or right here in the
-            markup for the page.
-        </p>
+                <button style="float: right; display: none;" class="stop-mic-record btn btn-square btn-success">
+                    stop
+                </button>
+            </section>
 
-        <p>
-            Please note that there are no "gotchas" or "correct" answers. Rather, we're
-            hoping to get a general feel for how you might respond and contribute to
-            preliminary work from another colleague.
-        </p>
 
-        <p>
-            We should be able to run your submission on a local web server without needing to invoke any
-            installation or build commands. For example, we should be able to evaluate your submission
-            without needing to run npm install (or similar) commands. You should feel free to use
-            third-party libraries. If you include a git repository with your submission, we will take a
-            look at your commit history.
-        </p>
+        </div>
+    </div>
+</body>
 
-    </body>
+
 </html>

--- a/main.js
+++ b/main.js
@@ -1,31 +1,82 @@
 import { XYPad } from './src/xy-pad.js';
 import { SamplePlayer } from './src/sample-player.js';
+import eventBus from './src/eventBus.js'
+import { Sequencer } from './src/sequencer.js'
+import MicRecorder from "./src/mic-recorder.js"
 
 document.addEventListener("DOMContentLoaded", () => {
-    const audioContext = new AudioContext({latencyHint: "playback", sampleRate: 44100});
-    const samplePlayer = new SamplePlayer(audioContext);
+    const XYPadEl = document.getElementById("xy_pad")
+    const startBtn = document.getElementById("start")
+    const stopBtn = document.getElementById("stop")
 
-    const xyPad = new XYPad(document.getElementById("xy_pad"), (e) => {
-        samplePlayer.setFilterCutoff((e.xPct / 100) * 10000);
-        samplePlayer.setPlaybackRate((1 - (e.yPct / 100)) * 2);
+    const audioContext = new AudioContext({ latencyHint: "playback", sampleRate: 44100 });
+    const sequencer = new Sequencer()
+    const micRecorder = new MicRecorder()
+    const xyPad = new XYPad(XYPadEl);
 
-        switch(e.type) {
-            case "down":
-                samplePlayer.startPlayback();
+    let recording = null
+
+    const samplePlayer = new SamplePlayer(audioContext, (e) => {
+        //This could also be managed with the EventBus.
+        switch (e.type) {
+            case "meterValue":
+                XYPadEl.style.outlineWidth = e.value + "px"
                 break;
-            case "up":
-                samplePlayer.stopPlayback();
-                break;
-            case "move":
+            case "stop":
+                XYPadEl.style.outlineWidth = "0px"
                 break;
         }
     });
 
-    samplePlayer.loadSample().then(() => {
-        document.getElementById("loading_indicator").innerHTML = "Sample Loaded!";
-    })
-
-    document.addEventListener("mousedown", (e) => {
+    document.addEventListener("mousedown", () => {
         audioContext.resume();
     });
+
+    startBtn.addEventListener("click", (e) => {
+        sequencer.startPlayback(recording)
+        samplePlayer.startPlayback()
+        
+        xyPad.isPlaying = true
+        XYPadEl.style.backgroundColor = "lightgreen"
+        stopBtn.style.display = "initial"
+        startBtn.style.display = "none"
+    });
+
+    stopBtn.addEventListener("click", () => {
+        xyPad.isPlaying = false
+        sequencer.stopPlayback()
+        samplePlayer.stopPlayback()
+    });
+
+    //Listening for XYPadEvents, works for recording and playback.
+    eventBus.on("down", () => {
+        //we start to record on mouseDown
+        sequencer.startRecord()
+        samplePlayer.startPlayback()
+        startBtn.classList.add("btn-disabled")
+    });
+    eventBus.on("move", (e) => {
+        samplePlayer.setFilterCutoff((e.xPct / 100) * 10000);
+        samplePlayer.setPlaybackRate((1 - (e.yPct / 100)) * 2);
+    });
+    eventBus.on("up", () => {
+        //we stop recording on mouseUp
+        samplePlayer.stopPlayback()
+        recording = sequencer.stopRecord()
+        sequencer.stopPlayback()
+        startBtn.classList.remove("btn-disabled")
+    });
+
+    //once the sequencer finished the playback we are displaying the play button again.
+    eventBus.on("playbackStop", () => {
+        xyPad.isPlaying = false
+        XYPadEl.style.backgroundColor = ""
+        stopBtn.style.display = "none"
+        startBtn.style.display = "initial"
+    });
 });
+
+
+
+
+

--- a/src/eventBus.js
+++ b/src/eventBus.js
@@ -1,0 +1,13 @@
+const eventBus = {
+    on(event, callback) {
+        document.addEventListener(event, (e) => callback(e.detail));
+    },
+    dispatch(event, data) {
+        document.dispatchEvent(new CustomEvent(event, { detail: data }));
+    },
+    remove(event, callback) {
+        document.removeEventListener(event, () => callback);
+    },
+};
+
+export default eventBus;

--- a/src/mic-recorder.js
+++ b/src/mic-recorder.js
@@ -1,0 +1,58 @@
+import eventBus from "./eventBus.js";
+
+/**
+ * this class takes care of recording a mic input and returns a ObjectURl linking to the recorded audio.
+ */
+export default class MicRecorder {
+    constructor() {
+        this.recordBtn = document.querySelector('.record-mic');
+        this.stopMicRecord = document.querySelector('.stop-mic-record');
+        this.initRecorder()
+    }
+    initRecorder() {
+        if (navigator.mediaDevices.getUserMedia) {
+            console.log('getUserMedia supported.');
+
+            const constraints = { audio: true };
+            let chunks = [];
+
+            let onSuccess = (stream) => {
+                const mediaRecorder = new MediaRecorder(stream);
+
+                this.recordBtn.onclick = () => {
+                    mediaRecorder.start();
+
+                    this.recordBtn.style.display = "none";
+                    this.stopMicRecord.style.display = "initial";
+                }
+
+                this.stopMicRecord.onclick = () => {
+                    mediaRecorder.stop();
+
+                    this.recordBtn.style.display = "initial";
+                    this.stopMicRecord.style.display = "none";
+                }
+
+                mediaRecorder.onstop = function (e) {
+                    const blob = new Blob(chunks, { 'type': 'audio/ogg; codecs=opus' });
+                    chunks = [];
+                    const audioURL = window.URL.createObjectURL(blob);
+                    eventBus.dispatch("sampleRecorded", { audioURL })
+                }
+
+                mediaRecorder.ondataavailable = function (e) {
+                    chunks.push(e.data);
+                }
+            }
+
+            let onError = function (err) {
+                console.log('The following error occured: ' + err);
+            }
+
+            navigator.mediaDevices.getUserMedia(constraints).then(onSuccess, onError);
+
+        } else {
+            console.log('getUserMedia not supported on your browser!');
+        }
+    }
+}

--- a/src/sample-player.js
+++ b/src/sample-player.js
@@ -1,41 +1,82 @@
+import eventBus from "./eventBus.js";
 export class SamplePlayer {
 
     audioBuffer = undefined;
     source = undefined;
 
-    constructor(audioContext) {
+    constructor(audioContext, callback) {
         this.audioContext = audioContext;
-        this.filter = new BiquadFilterNode(this.audioContext);
+        this.callback = callback
+        this.filter = new Tone.BiquadFilter().toDestination();
+        this.meter = new Tone.Meter();
         this.filter.type = "lowpass";
-        this.filter.connect(this.audioContext.destination);
+        this.filter.connect(this.meter)
+        this.meterInterval = null
+
+        this.loadSample("/assets/drum-loop-102-bpm.wav").then(() => {
+            console.log("Sample Loaded!");
+        })
+
+        eventBus.on("sampleRecorded", (e) => {
+            this.loadSample(e.audioURL).then(() => {
+                console.log("Sample Loaded!");
+            })
+        });
     }
 
-    loadSample() {
-        return fetch("/assets/drum-loop-102-bpm.wav")
+    loadSample(sampleUrl) {
+        return fetch(sampleUrl)
             .then(response => response.arrayBuffer())
             .then(audioData => this.audioContext.decodeAudioData(audioData))
             .then(audioBuffer => this.audioBuffer = audioBuffer);
     }
 
     startPlayback() {
-        this.source = this.audioContext.createBufferSource();
+        this.source = new Tone.Player()
         this.source.buffer = this.audioBuffer;
         this.source.loop = true;
         this.source.connect(this.filter);
         this.source.start();
+
+        // get current level of the track
+        this.meterInterval = setInterval(() => {
+            this.callback({ type: "meterValue", value: this.getPositiveMeterValues(this.meter.getValue()) })
+        }, 50);
+    }
+
+    /**
+     * since tone.js meter is returning RMS value from -infinity to 0
+     * we convert those values to positive and clamp them in order to create our visualization
+     */
+    getPositiveMeterValues(value) {
+        const resolution = 4
+        const minValue = 0
+        const maxValue = 100
+        const PositiveMappedValue = (maxValue - (value * -1)) / resolution
+        return this.clamp(PositiveMappedValue, minValue, maxValue)
+    }
+
+    clamp(value, min, max) {
+        return Math.min(Math.max(value, min), max);
     }
 
     stopPlayback() {
-        this.source.stop();
+        if (this.source) {
+            this.source.stop();
+            clearInterval(this.meterInterval);
+            this.callback({ type: "stop" })
+        }
     }
 
     setFilterCutoff(frequency) {
-        this.filter.frequency.value = frequency;
+        if (frequency) {
+            this.filter.frequency.value = frequency;
+        }
     }
 
     setPlaybackRate(pct) {
-        if (this.source) {
-            this.source.playbackRate.value = pct;
+        if (this.source && pct) {
+            this.source.playbackRate = pct;
         }
     }
 }

--- a/src/sequencer.js
+++ b/src/sequencer.js
@@ -1,0 +1,196 @@
+import eventBus from "./eventBus.js";
+
+/**
+ * the sequencer worker allow us to have a steady event loop.
+ * We are using it to trigger a "step" event every x time.
+ * (Ideally a worker-loader should be configured for production)
+ */
+const sequencerWorker = new Worker("./worker/sequencer.worker.js");
+
+const newRecording = () => ({
+    id: new Date().valueOf().toString(),
+    bars: [],
+    bpm: 120,
+});
+
+/**
+ * Step-sequencer to record and play notes on a given tempo.
+ * A recording is made of a mulitdimensionnal array made of Bars,Steps and Notes.
+ * Notes are stored in Steps. Steps are stored in Bars. Bars are stored in a recording.
+ * {Notes} < [Steps] < [Bars] < {recording}
+ */
+export class Sequencer {
+    // Higher the number better the precision of the recording. should be always even.
+    numberOfStepsPerBeat = 16;
+    // Common 4/4 time signature.
+    numberOfBeatsPerBar = 4;
+
+    recording = newRecording();
+    bar = [];
+    step = [];
+
+    stepIndex = 0;
+    barIndex = 0;
+
+    isRecording = false;
+    isPlaying = false;
+
+    constructor() {
+        this.subscribeToEvents();
+    }
+
+    /**
+     * Init new recording's state and start the sequencer worker.
+     */
+    startRecord = () => {
+        if (this.isRecording) return;
+        this.isRecording = true;
+
+        this.initNewRecording();
+        this.setSequencerStepInterval();
+        this.seekTransport({ bar: 0, step: 0 });
+
+        // Start the sequencer.
+        sequencerWorker.postMessage("start");
+
+        sequencerWorker.onmessage = (ev) => {
+            if (ev.data === "step") {
+                // Create a new blank step.
+                this.step = [];
+                // Move sequence to the next step.
+                this.stepIndex++;
+
+                this.pushStepToBar();
+
+                // When nb of steps reached the number of steps per bar.
+                if (!(this.stepIndex % (this.numberOfStepsPerBeat * this.numberOfBeatsPerBar))) {
+                    this.pushBarToRecording();
+                    // Create a new empty bar.
+                    this.bar = [];
+                    // Reset step count for the new bar.
+                    this.stepIndex = 0;
+                }
+            }
+        };
+    };
+
+    /**
+     * Stop the reccording, push the last notes in the recording and stop the sequencer.
+     * @returns
+     */
+    stopRecord = () => {
+        this.isRecording = false;
+
+        // Push last bar steps even uncompleted.
+        if (this.stepIndex) {
+            this.pushBarToRecording();
+        }
+
+        // Stop the sequencer.
+        sequencerWorker.postMessage("stop");
+        return this.recording;
+    };
+
+    // We use document level event listener to ensure a faster listening of keyboards evt.
+    // When an event occur we store the note in the actual step.
+    subscribeToEvents() {
+        eventBus.on("down", (e) => this.onEvent(e));
+        eventBus.on("move", (e) => this.onEvent(e));
+        eventBus.on("up", (e) => this.onEvent(e));
+    }
+
+    /**
+     * Calculate the exact interval time between steps using recording bpm and nb of steps per bar.
+     * @returns {Number} interval in ms
+     */
+    setSequencerStepInterval = () => {
+        const interval = (60 / this.recording.bpm / this.numberOfStepsPerBeat) * 1000;
+        sequencerWorker.postMessage({ interval });
+
+        return interval;
+    };
+
+    initNewRecording = () => {
+        this.recording = newRecording();
+        this.bar = [];
+        this.step = [];
+    };
+
+    pushStepToBar = () => {
+        this.bar.push({ notes: this.step });
+    };
+
+    pushBarToRecording = () => {
+        this.recording.bars.push({ steps: this.bar });
+    };
+
+    onEvent(e) {
+        if (!this.isRecording) return;
+        this.step.push(e);
+    }
+
+    /**
+     * Takes care of playing a recording.
+     * It's going through the sequence's data using the same worker as for recording.
+     * This guarantee a very close representation of the original sequence.
+     * @returns void
+     */
+    startPlayback(recording) {
+        this.recording = recording;
+        //Setting sequencer interval to match with recorging bpm.
+        this.setSequencerStepInterval();
+
+        if (this.isPlaying) return;
+        this.isPlaying = true;
+        this.seekTransport({ bar: 0, step: 0 });
+
+
+        sequencerWorker.postMessage("start");
+
+        sequencerWorker.onmessage = (ev) => {
+            if (ev.data === "step") {
+                // we are performing the same indexing as recording.
+                this.stepIndex++;
+                if (!(this.stepIndex % (this.numberOfStepsPerBeat * this.numberOfBeatsPerBar))) {
+                    this.barIndex++;
+                    this.stepIndex = 0;
+                }
+            }
+
+            // If the step is having data, we dispatch an event.
+            if (
+                this.recording.bars[this.barIndex] &&
+                this.recording.bars[this.barIndex].steps[this.stepIndex]
+            ) {
+                this.recording.bars[this.barIndex].steps[this.stepIndex].notes.forEach((note) => {
+                    if (note.type === "up") {
+                        eventBus.dispatch("up", note);
+                    }
+                    if (note.type === "move") {
+                        eventBus.dispatch("move", note);
+                    }
+                    if (note.type === "down") {
+                        eventBus.dispatch("down", note);
+                    }
+                });
+            } else {
+                this.stopPlayback();
+            }
+        };
+    }
+
+    stopPlayback() {
+        this.isPlaying = false;
+        sequencerWorker.postMessage("stop");
+        eventBus.dispatch("playbackStop")
+    }
+
+    /**
+     * Allow us to navigate through a sequence using indexes of bars and steps.
+     * @returns void
+     */
+    seekTransport({ bar = 0, step = 0 }) {
+        this.barIndex = bar;
+        this.stepIndex = step;
+    }
+}

--- a/src/xy-pad.js
+++ b/src/xy-pad.js
@@ -1,8 +1,11 @@
+//Events here are dispatched in two places, main.js and sequencer.js.
+import eventBus from "./eventBus.js";
 export class XYPad {
 
     constructor(element, callback) {
         this.element = element;
         this.callback = callback;
+        this.isPlaying = false
 
         this.dot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
         this.element.appendChild(this.dot);
@@ -11,20 +14,31 @@ export class XYPad {
         element.addEventListener("mousedown", (e) => {
             let [xPct, yPct] = this.getPositionInPercentages(e);
             this.updateDot(xPct, yPct, 0.5);
-            this.callback({type: "down", xPct, yPct});
+            eventBus.dispatch("down", { type: "down", xPct, yPct });
+
         });
 
         element.addEventListener("mousemove", (e) => {
+            if (this.isPlaying) return
             let [xPct, yPct] = this.getPositionInPercentages(e);
             this.updateDot(xPct, yPct);
-            this.callback({type: "move", xPct, yPct});
+            eventBus.dispatch("move", { type: "move", xPct, yPct });
         });
 
         element.addEventListener("mouseup", (e) => {
             let [xPct, yPct] = this.getPositionInPercentages(e);
             this.updateDot(xPct, yPct, 0.1);
-            this.callback({type: "up", xPct, yPct});
+            eventBus.dispatch("up", { type: "up", xPct, yPct });
         });
+
+        // force stopping playback in case the cursor is ourside the Pad's area.
+        document.addEventListener("mouseup", (e) => {
+            eventBus.dispatch("up", { type: "up" });
+        });
+
+        eventBus.on("move", (e) => {
+            this.updateDot(e.xPct, e.yPct);
+        })
     }
 
     getPositionInPercentages(e) {

--- a/styles.css
+++ b/styles.css
@@ -1,28 +1,30 @@
 p { max-width: 600px; }
 
 .two_row {
-    display: flex;
-    flex-direction: column;
-    width: 80%;
-    margin-right: auto;
+    width: 300px;
+    margin-top:2em;
     margin-left: auto;
-    margin-top: 2em;
-    margin-bottom: 2em;
+    margin-right: auto;
 }
 
-.xy_pad {
+#xy_pad {
     width: 300px;
     height: 300px;
     background-color: #eee;
     transition: background-color 0.25s;
+    transition: outline-width 0.05s;
     flex-shrink: 0;
     cursor: pointer;
     position: relative;
     margin-left: auto;
     margin-right: auto;
+    outline-style: solid;
+    outline-color: grey;
+    outline-width: 0px;
+    margin-bottom:24px;
 }
 
-.xy_pad:hover {
+#xy_pad:hover {
     background-color: lightpink;
 }
 

--- a/worker/sequencer.worker.js
+++ b/worker/sequencer.worker.js
@@ -1,0 +1,24 @@
+var timer = null;
+var interval = 100; // default interval, this is set before recording or playing.
+
+self.onmessage = function (e) {
+    if (e.data == "start") {
+        // Start event loop.
+        timer = setInterval(function () {
+            postMessage("step");
+        }, interval);
+    } else if (e.data.interval) {
+        // Set loop inteval.
+        interval = e.data.interval;
+        if (timer) {
+            clearInterval(timer);
+            timer = setInterval(function () {
+                postMessage("step");
+            }, interval);
+        }
+    } else if (e.data == "stop") {
+        // Stop event loop.
+        clearInterval(timer);
+        timer = null;
+    }
+};


### PR DESCRIPTION
### **Add a step sequencer and a mic recording.**

![Screenshot 2022-10-19 at 18 10 21](https://user-images.githubusercontent.com/37188196/196746371-28c7d45c-3012-4d48-8feb-603a8bf73905.png)

In the little prompt asking what we could bring to learning Music/Synth, I suggested the idea of writing a little chapter on the history of sampling. So I connected this idea with the challenge.

I suggested giving the user the ability to play with their own samples.

That being said, I implemented here three features:
 - Mic recorder: the mic recorder is allowing the user to record and play with their own samples.

 - Gain visualization on the xyPad: I used Tone.js Meter to create a Gain visualizer around the XY pad. 

 - Step sequencer: the sequencer is taking care of replaying the user interaction precisely. It is simulating mouse events, so the user can see exactly what they played. it is using a web worker to generate a consistent and steady loop event.

## What else has been done 
 - Converted actual web audio nodes to Tone.js nodes in order to use a meter node.
 - Fixed a bug due to an un-triggered mouseUp event when the user is moving the cursor out of the xyPad area. We are now listening for window mouseUp events and forcing the playback to stop.
 - refactor xyPad events callback.
 - Implementing an EventBus to do bidirectional event dispatch across different files, also improves code readability.
 - installed Tailwind and daisyUI  via CDN  to improve overall UI.

 